### PR TITLE
Feature: support hypercore:v8 extensions api

### DIFF
--- a/index.js
+++ b/index.js
@@ -460,9 +460,11 @@ class Decentstack extends EventEmitter {
 
     Object.assign(impl, {
       _id: fastHash(name),
-      _codec: codecs(impl.encoding),
-      get name () { return name }
+      _codec: codecs(impl.encoding)
     })
+    if (impl.name !== name) {
+      impl.name = name
+    }
 
     impl.send = (message, peer) => {
       const buff = impl.encoding ? impl._codec.encode(message) : message

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,6 +8,12 @@ module.exports = Object.freeze({
   // has to reply to a 'Manifest' before the peer is considered
   // inactive
   REQUEST_TIMEOUT: 500, // TODO: 30 sec is a more realistic value?,
+
+  // In non live mode, the time we should wait for the remote to send an manifest
+  // before disconnecting. Is used to close a connection when only one side shares.
+  // and the other only accepts
+  EXCHANGE_TIMEOUT: 1000,
+
   // Default value for how long we wait
   // before performing strict feed identification
   FEED_IDENTIFICATION_TIMEOUT: 1000

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -1,0 +1,180 @@
+const { Exchange } = require('./messages')
+const { REQUEST_TIMEOUT } = require('./constants')
+
+class CoreExchangeExtension {
+  constructor (handlers) {
+    this.name = 'exchange'
+    this.encoding = Exchange
+    this.handlers = {
+      onmanifest (snapshot) {
+        throw new Error('Unhandeled Manifest message')
+      },
+      onrequest (keys) {
+        throw new Error('Unhandeled ReplicationRequest message')
+      },
+      ...handlers
+    }
+
+    // Manifest id counter
+    this.__mctr = 0
+
+    // namespaced arrays
+    this.offeredKeys = {}
+    this.requestedKeys = {}
+    this.remoteOfferedKeys = {}
+
+    this.pendingRequests = {
+    }
+  }
+
+  onmessage (msg, peer) {
+    try {
+      if (msg.manifest) {
+        const m = {
+          id: msg.manifest.id,
+          namespace: msg.manifest.namespace,
+          keys: msg.manifest.feeds.map(f => f.key.hexSlice()),
+          meta: msg.manifest.feeds.map(f => {
+            const meta = {}
+            f.headers.forEach(kv => {
+              meta[kv.key] = JSON.parse(kv.value)
+            })
+            return meta
+          })
+        }
+
+        // Register what remote offered.
+        this.remoteOfferedKeys[m.namespace] = this.remoteOfferedKeys[m.namespace] || []
+        m.keys.forEach(key => {
+          if (this.remoteOfferedKeys[m.namespace].indexOf(key) === -1) {
+            this.remoteOfferedKeys[m.namespace].push(key)
+          }
+        })
+        process.nextTick(() => this.handlers.onmanifest(m, peer))
+      } else if (msg.req) {
+        peer.stats.requestsRecv++
+        const req = msg.req
+
+        // Fullfill any internal promises
+        if (this.pendingRequests[req.manifest_id]) {
+          this.pendingRequests[req.manifest_id](null, req.keys)
+        }
+        process.nextTick(() => this.handlers.onrequest(req, peer))
+      } else {
+        throw new Error(`Unhandled Exchange message: ${Object.keys(msg).join(',')}`)
+      }
+    } catch (err) {
+      peer.kill(err)
+    }
+  }
+
+  sendManifest (namespace, manifest, cb) {
+    const mid = ++this.__mctr
+    // Save which keys were offered on this connection
+    this.offeredKeys[namespace] = this.offeredKeys[namespace] || []
+
+    manifest.keys.forEach(k => {
+      if (this.offeredKeys[namespace].indexOf(k) === -1) {
+        this.offeredKeys[namespace].push(k)
+      }
+    })
+
+    const message = {
+      manifest: {
+        namespace,
+        id: mid,
+        feeds: manifest.keys.map((key, n) => {
+          const meta = manifest.meta[n]
+          return {
+            key: Buffer.from(key, 'hex'),
+            headers: Object.keys(meta).map(k => {
+              return {
+                key: k,
+                value: JSON.stringify(meta[k])
+              }
+            })
+          }
+        })
+      }
+    }
+
+    if (typeof cb === 'function') {
+      let triggered = false
+      const race = (err, f) => {
+        if (!triggered) {
+          triggered = true
+          delete this.pendingRequests[mid]
+          cb(err, f)
+        }
+      }
+
+      this.pendingRequests[mid] = race
+
+      setTimeout(() => {
+        race(new ManifestResponseTimedOutError())
+      }, REQUEST_TIMEOUT)
+    }
+
+    this.send(message)
+    return mid
+  }
+
+  sendRequest (namespace, keys, manifestId) {
+    this.requestedKeys[namespace] = this.requestedKeys[namespace] || []
+    keys.forEach(k => {
+      if (this.requestedKeys[namespace].indexOf(k) === -1) {
+        this.requestedKeys[namespace].push(k)
+      }
+    })
+
+    const message = {
+      req: {
+        namespace,
+        manifest_id: manifestId,
+        keys: keys.map(k => Buffer.from(k, 'hex'))
+      }
+    }
+    this.send(message)
+  }
+
+  /*
+   * Same as negotiatedKeysNS except returns a flat array of keys
+   */
+  get negotiatedKeys () {
+    return Object.keys(this.negotiatedKeysNS)
+  }
+
+  /*
+   * Each peer allows offered-keys, requested-keys and the ~~exchange-key~~
+   * to be replicated on the stream
+   * negotiated = offered - requested for each namespace
+   * as key value, { feedKey: namespace, ... }
+   */
+  get negotiatedKeysNS () {
+    const m = {}
+    // Presumably not needed anymore after proto:v7 upgrade,
+    // the exchangeKey is implicitly allowed otherwise we wouldn't
+    // be exchanging any messages to begin with.
+    // m[this.exchangeChannel.key.hexSlice()] = null
+
+    Object.keys(this.offeredKeys).forEach(ns => {
+      this.offeredKeys[ns].forEach(k => { m[k] = ns })
+    })
+    Object.keys(this.requestedKeys).forEach(ns => {
+      this.requestedKeys[ns].forEach(k => { m[k] = ns })
+    })
+    return m
+  }
+}
+
+module.exports = CoreExchangeExtension
+
+class ManifestResponseTimedOutError extends Error {
+  constructor (msg = 'timeout while waiting for request after manifest', ...params) {
+    super(msg, ...params)
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) Error.captureStackTrace(this, ManifestResponseTimedOutError)
+
+    this.name = this.type = 'ManifestResponseTimedOutError'
+  }
+}

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -6,47 +6,45 @@ const pump = require('pump')
 const debugFactory = require('debug')
 const { defer } = require('deferinfer')
 const { assertCore } = require('./util')
-const { Exchange } = require('./messages')
 const substream = require('hypercore-protocol-substream')
 const ph = require('pretty-hash')
+const { h32 } = require('xxhashjs')
 const codecs = require('codecs')
+const CoreExchangeExtension = require('./exchange')
 
 const {
   STATE_INIT,
   STATE_ACTIVE,
   STATE_DEAD,
   PROTOCOL_VERSION,
-  REQUEST_TIMEOUT,
-  EXCHANGE
+  EXCHANGE_TIMEOUT
 } = require('./constants')
 
-const _exchange = {
-  encoding: Exchange,
-  onmessage (decodedMessage, peer) {
-    debugger
-  }
-}
-
-class PeerConnection extends EventEmitter {
+class PeerConnection {
   constructor (initiator, exchangeKey, opts = {}) {
-    super()
     assert(typeof initiator === 'boolean', 'First argument `initiator` must be a boolean!')
     assert(typeof exchangeKey === 'string' || Buffer.isBuffer(exchangeKey), 'Second arg `exchangeKey` must be a string or buffer')
     this._id = Buffer.from(Array.from(new Array(6)).map(() => Math.floor(256 * Math.random())))
     this.initiator = initiator
     this.state = STATE_INIT
-    this.__mctr = 0
     this.opts = opts || {}
     this.useVirtual = !!opts.useVirtual && false // Disabled for now.
     this.activeVirtual = []
-    this.extensions = []
-    this.remoteExtensionNames = []
+    this._extensions = {}
 
-    // namespaced arrays
-    this.offeredKeys = {}
-    this.requestedKeys = {}
-    this.remoteOfferedKeys = {}
+    // Lift off handlers from options.
+    this.handlers = {
+      onmanifest: opts.onmanifest,
+      onrequest: opts.onrequest,
+      onstatechange: opts.onstatechange,
+      onreplicating: opts.onreplicating
+    }
+    delete opts.onmanifest
+    delete opts.onrequest
+    delete opts.onstatechange
+    delete opts.onreplicating
 
+    // Initialize stats
     this.stats = {
       snapshotsSent: 0,
       snapshotsRecv: 0,
@@ -56,16 +54,18 @@ class PeerConnection extends EventEmitter {
       channelesClosed: 0
     }
 
+    // Normalize exchange key
     if (typeof exchangeKey === 'string') exchangeKey = Buffer.from(exchangeKey, 'hex')
-
-    // TODO: this.exchangeKey = hash(inputKey + 'ex:v1' + PROTOCOL_VERSION)
     this.exchangeKey = exchangeKey
+
+    // Initialize individual debug handle
     this.debug = debugFactory(`decentstack/repl/${this.shortid}`)
 
 
     // Pre-bind our listeners before registering them, to be able to safely remove them
     this.kill = this.kill.bind(this)
 
+    // Create our stream
     this.stream = new Protocol(initiator, {
       onhandshake: this._onHandshake.bind(this),
       ondiscoverykey: this._onChannelOpened.bind(this),
@@ -80,23 +80,37 @@ class PeerConnection extends EventEmitter {
     */
 
     // Register the core-exchange protocol
-    this.exchangeExt = this.registerExtension(EXCHANGE, _exchange)
+    this.exchangeExt = this.registerExtension(new CoreExchangeExtension({
+      onmanifest: (snapshot, peer) => {
+        this.stats.snapshotsRecv++
+        this.debug(`Received manifest #${snapshot.id}`)
+        // Forward upwards
+        if (typeof this.handlers.onmanifest === 'function') this.handlers.onmanifest(snapshot, peer)
+      },
+      onrequest: (req, peer) => {
+        peer.debug(`Received replication request for ${req.keys.length} feeds`)
+        // Forward upwards
+        if (typeof this.handlers.onrequest === 'function') this.handlers.onrequest(req, peer)
+      }
+    }))
 
     // Clean up theese two as well
     let resolveRemoteVersion = null
     const remoteVersionPromise = defer(d => { resolveRemoteVersion = d })
 
+    // Create the channel that we're going to use for exchange signaling.
     this.exchangeChannel = this.stream.open(this.exchangeKey, {
       onextension: this._onExtension.bind(this),
       onoptions: (opts) => {
         // Hack, remote version is packed into first element of extensions array
         resolveRemoteVersion(null, opts.extensions.shift())
-        this.remoteExtensions = opts.extensions
       },
       onopen: async () => {
         this.debug('Exchange Channel opened', ph(this.exchangeKey))
         if (!this.stream.remoteVerified(this.exchangeKey)) throw new Error('open and unverified')
-        this._sendOptions()
+        this.exchangeChannel.options({
+          extensions: [PROTOCOL_VERSION]
+        })
 
         // TODO: clean up, it's not pretty.
         const [lNameVer] = PROTOCOL_VERSION.split('.')
@@ -111,8 +125,9 @@ class PeerConnection extends EventEmitter {
       }
     })
 
-    this.debug(`Initializing new PeerConnection(${this.initiator}) extensions:`, this._rextlut)
+    this.debug(`Initializing new PeerConnection(${this.initiator}) extensions:`, Object.values(this._extensions).map(i => i.name))
 
+    // Register end-of-stream handler
     eos(this.stream, err => {
       this.kill(err, true)
     })
@@ -126,33 +141,11 @@ class PeerConnection extends EventEmitter {
     return this._id.hexSlice(0, 4)
   }
 
-  /* TODO: Shouldn't be needed anymore
-   * Used to detect if non-negotiated feeds enter the stream
-   * Each peer allows offered-keys, requested-keys and the exchange-key
-   * to be replicated on the stream
-   */
-  get allowedKeys () {
-    return Object.keys(this.allowedKeysNS)
-  }
-
-  get allowedKeysNS () {
-    const m = {}
-    m[this.exchangeChannel.key.hexSlice()] = null
-
-    Object.keys(this.offeredKeys).forEach(ns => {
-      this.offeredKeys[ns].forEach(k => { m[k] = ns })
-    })
-    Object.keys(this.requestedKeys).forEach(ns => {
-      this.requestedKeys[ns].forEach(k => { m[k] = ns })
-    })
-    return m
-  }
-
   // Forward extension to virtual feed.
   extension (name, ...args) {
     const id = fastHash(name)
     // Register new extensions dynamically
-    if (!this._rextlut[id]) this._rextlut[id] = name
+    if (!this._extensions[id]) this._extensions[id] = name
     this.exchangeChannel.extension(id, ...args)
   }
 
@@ -168,23 +161,28 @@ class PeerConnection extends EventEmitter {
     const prevState = this.state
     this.state = newState
 
-    // Log error if no 'state-change' listeners available to handle it.
-    if (err && !this.listeners('state-change').length) {
+
+    if (typeof this.handlers.onstatechange === 'function') {
+      this.handlers.onstatechange(newState, prevState, err, this)
+    } else if (err) {
+      // Log error if no 'state-change' listeners available to handle it.
       console.error('PeerConnection received error during `state-change` event, but no there are no registered handlers for it!\n', err)
     }
 
-    this.emit('state-change', newState, prevState, err, this)
-
     switch (this.state) {
       case STATE_DEAD:
-        this.emit('end', err, this)
+        if (typeof this.handlers.onclose === 'function') {
+          this.handlers.onclose(err, this)
+        }
         break
       case STATE_ACTIVE:
         // wedge the stream. released in kill()#cleanup()
         // our exchangeChannel already works as a wedge.
         // if (this.opts.live) this.stream.prefinalize.wait()
         // if (this.opts.live) this.stream.prefinalize.continue() // this dosen't make sense. stream is already marked for death.
-        this.emit('connected', null, this)
+        if (typeof this.handlers.onopen === 'function') {
+          this.handlers.onopen(null, this)
+        }
         break
     }
   }
@@ -233,37 +231,28 @@ class PeerConnection extends EventEmitter {
   }
 
   registerExtension (name, impl) {
-    impl = { ...impl } // Make a copy
-    impl._codec = codecs(impl.encoding)
-
-    Object.defineProperty(impl, 'name', {
-      get () { return name }
+    if (!impl && typeof name.name === 'string') return this.registerExtension(name.name, name)
+    Object.assign(impl, {
+      _id: fastHash(name),
+      _codec: codecs(impl.encoding),
+      get name () { return name }
     })
 
     impl.send = message => {
       const buff = impl.encoding ? impl._codec.encode(message) : message
-      this.exchangeChannel.extension(name, buff)
+      this.exchangeChannel.extension(impl._id, buff)
     }
 
     impl.broadcast = impl.send
 
     impl.destroy = () => {
-      this.debug('Unregister extension', name, impl._id)
-      this.extensions[impl._id] = null
-      this._sendOptions()
+      this.debug('Unregister extension', name, impl._id.toString(16))
+      this._extentions[impl._id] = null
     }
 
-    impl._id = this.extensions.push(impl)
-    this.debug('Register extension', name, impl._id)
-    this._sendOptions()
+    this._extensions[impl._id] = impl
+    this.debug('Register extension', name, impl._id.toString(16))
     return impl
-  }
-
-  _sendOptions () {
-    if (!this.exchangeChannel) return
-    this.exchangeChannel.options({
-      extensions: [PROTOCOL_VERSION, ...this.extensions.map(i => i.name)]
-    })
   }
 
   _onChannelOpened (discoveryKey) {
@@ -273,28 +262,6 @@ class PeerConnection extends EventEmitter {
       const verified = this.stream.remoteVerified(discoveryKey)
       if (!verified) return this.kill(new Error('Remote uses a different exchangeKey'))
     }
-
-    return // don't below code is needed anymore. It's built into hypercore-proto now.
-    // Give both ends to some time to finish feed negotiations,
-    // if feed is not accepted by the time the timeout triggers
-    // then we have an 'unwanted feed' in our stream.
-    setTimeout(() => {
-      const feedKey = this.allowedKeys.find(feedKey => {
-        return discoveryKey(Buffer.from(feedKey, 'hex'))
-          .equals(discoveryKey)
-      })
-      if (feedKey && !this.exchangeKey.equals(Buffer.from(feedKey, 'hex'))) {
-        // don't emit the exchange key as a feed event
-        this.emit('feed', feedKey, this)
-      } else if (!feedKey) {
-        // I'd like to keep track of all feeds, but truth is that there is no
-        // way to link sub-cores to their original composite cores.
-        // So until we get some changes in hypercore/protocol we're not going
-        // to be able to drop peers that share unknown feeds.
-        // this.debug('Unknown feed encountered in stream, dkey:', ph(discoveryKey))
-        this.kill(new Error(`UnknownFeedError, identification timed out: ${discoveryKey.hexSlice()}`))
-      }
-    }, REQUEST_TIMEOUT)
   }
 
   _onChannelClosed (dk, pk) {
@@ -319,7 +286,7 @@ class PeerConnection extends EventEmitter {
           // Close the exchange channel
           this.debug('post-close timeout triggered')
           this.exchangeChannel.close()
-        }, REQUEST_TIMEOUT) // maybe use a different timeout here.
+        }, EXCHANGE_TIMEOUT) // maybe use a different timeout here.
       }
       // this.exchangeChannel.close() // <-- politely let nanoguard do it's job
       // this.stream.finalize() // <-- force everything to close.
@@ -327,135 +294,30 @@ class PeerConnection extends EventEmitter {
   }
 
   sendManifest (namespace, manifest, cb) {
-    const mid = ++this.__mctr
-    // Save which keys were offered on this connection
-    this.offeredKeys[namespace] = this.offeredKeys[namespace] || []
-    manifest.keys.forEach(k => {
-      if (this.offeredKeys[namespace].indexOf(k) === -1) {
-        this.offeredKeys[namespace].push(k)
-      }
-    })
-
-    const bin = Exchange.encode({
-      manifest: {
-        namespace,
-        id: mid,
-        feeds: manifest.keys.map((key, n) => {
-          const meta = manifest.meta[n]
-          return {
-            key: Buffer.from(key, 'hex'),
-            headers: Object.keys(meta).map(k => {
-              return {
-                key: k,
-                value: JSON.stringify(meta[k])
-              }
-            })
-          }
-        })
-      }
-    })
-
-    if (typeof cb === 'function') {
-      const evName = `manifest-${mid}`
-      // TODO: using a promise here might be cleaner
-      let triggered = false
-      const race = (err, f) => {
-        if (!triggered) {
-          triggered = true
-          cb(err, f)
-        }
-      }
-      this.once(evName, race)
-      setTimeout(() => {
-        this.removeListener(evName, race)
-        race(new ManifestResponseTimedOutError())
-      }, REQUEST_TIMEOUT)
-    }
-
-    this.debug(`manifest#${mid} sent with ${manifest.keys.length} keys`)
+    const mid = this.exchangeExt.sendManifest(namespace, manifest, cb)
     this.stats.snapshotsSent++
-    this.extension(EXCHANGE, bin)
+    this.debug(`manifest#${mid} sent with ${manifest.keys.length} keys`)
   }
 
-  sendRequest (namespace, keys, manifestId, cb) {
-    this.requestedKeys[namespace] = this.requestedKeys[namespace] || []
-    keys.forEach(k => {
-      if (this.requestedKeys[namespace].indexOf(k) === -1) {
-        this.requestedKeys[namespace].push(k)
-      }
-    })
-
-    const bin = Exchange.encode({
-      req: {
-        namespace,
-        manifest_id: manifestId,
-        keys: keys.map(k => Buffer.from(k, 'hex'))
-      }
-    })
+  sendRequest (namespace, keys, manifestId) {
+    this.exchangeExt.sendRequest(namespace, keys, manifestId)
     this.debug(`Replication request sent for mid#${manifestId} with ${keys.length} keys`)
     this.stats.requestsSent++
-    this.extension(EXCHANGE, bin)
   }
 
   _onExtension (id, message) {
-    const ext = this.extensions[id]
-    debugger
-    if (ext._codec) message = ext._codec.decode(message)
+    const ext = this._extensions[id]
 
-    if (typeof type === 'undefined') return console.warn('Unrecognized extension', id)
-
-    // Ignore message if not meant for us.
-    if (type !== EXCHANGE) {
-      this.emit('extension', type, message) // old emitter behaviour.
-      return
-    }
-
-    try {
-      const msg = Exchange.decode(message)
-
-      if (msg.manifest) {
-        this.stats.snapshotsRecv++
-        const m = {
-          id: msg.manifest.id,
-          namespace: msg.manifest.namespace,
-          keys: msg.manifest.feeds.map(f => f.key.hexSlice()),
-          meta: msg.manifest.feeds.map(f => {
-            const meta = {}
-            f.headers.forEach(kv => {
-              meta[kv.key] = JSON.parse(kv.value)
-            })
-            return meta
-          })
-        }
-
-        // Register what remote offered.
-        this.remoteOfferedKeys[m.namespace] = this.remoteOfferedKeys[m.namespace] || []
-        m.keys.forEach(key => {
-          if (this.remoteOfferedKeys[m.namespace].indexOf(key) === -1) {
-            this.remoteOfferedKeys[m.namespace].push(key)
-          }
-        })
-
-        this.debug(`Received manifest #${m.id}`)
-        process.nextTick(() => this.emit('manifest', m, this))
-      } else if (msg.req) {
-        this.stats.requestsRecv++
-        const req = msg.req
-
-        // Fullfill any internal promises
-        const evName = `manifest-${req.manifest_id}`
-        if (req.manifest_id && this.listeners(evName).length) {
-          this.emit(evName, null, req.keys)
-        }
-        this.debug(`Received replication request for ${req.keys.length} feeds`)
-        // Forward event upwards
-        this.emit('replicate', req, this)
-      } else {
-        throw new Error(`Unhandled Exchange message: ${Object.keys(msg).join(',')}`)
+    // bubble the message if it's not registered on this peer connection.
+    if (typeof ext === 'undefined') {
+      if (this.handlers && typeof this.handlers.onextension === 'function') {
+        this.handlers.onextension(id, message, this)
       }
-    } catch (err) {
-      this.kill(err)
+      return // Do not process further
     }
+
+    if (ext._codec) message = ext._codec.decode(message)
+    ext.onmessage(message, this)
   }
 
   get activeChannels () {
@@ -512,10 +374,10 @@ class PeerConnection extends EventEmitter {
           cleanUp()
         })
 
-        // notify manager that a new feed is replicated here,
-        // The manager will forward this event other connections that not
-        // yet have this feed listed in their knownFeeds
-        this.emit('feed', feed.key.hexSlice(), this)
+        // notify above about new feed being replicated
+        if (typeof this.handlers.onreplicating === 'function') {
+          this.handlers.onreplicating(feed.key, this)
+        }
         return cb(null, virtualStream)
       })
     } else {
@@ -527,9 +389,11 @@ class PeerConnection extends EventEmitter {
       }))
       this.debug('replicating feed:', ph(feed.discoveryKey), ph(feed.key))
       // notify manager that a new feed is replicated here,
-      // The manager will forward this event other connections that not
+      // The manager will forward this event to other connections that not
       // yet have this feed listed in their knownFeeds
-      this.emit('feed', feed.key.hexSlice(), this)
+      if (typeof this.handlers.onreplicating === 'function') {
+        this.handlers.onreplicating(feed.key, this)
+      }
       return cb(null, stream)
     }
   }
@@ -537,13 +401,7 @@ class PeerConnection extends EventEmitter {
 
 module.exports = PeerConnection
 
-class ManifestResponseTimedOutError extends Error {
-  constructor (msg = 'timeout while waiting for request after manifest', ...params) {
-    super(msg, ...params)
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    if (Error.captureStackTrace) Error.captureStackTrace(this, ManifestResponseTimedOutError)
-
-    this.name = this.type = 'ManifestResponseTimedOutError'
-  }
+function fastHash (name) {
+  return h32(name, 0xfeed).toNumber()
 }
 

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -20,6 +20,13 @@ const {
   EXCHANGE
 } = require('./constants')
 
+const _exchange = {
+  coding: Exchange,
+  onmessage (decodedMessage, peer) {
+    debugger
+  }
+}
+
 class PeerConnection extends EventEmitter {
   constructor (initiator, exchangeKey, opts = {}) {
     super()
@@ -32,9 +39,10 @@ class PeerConnection extends EventEmitter {
     this.opts = opts || {}
     this.useVirtual = !!opts.useVirtual && false // Disabled for now.
     this.activeVirtual = []
-    this.extensions = new Map()
-    this.remoteExtensions = []
-
+    this.extensions = []
+    this.remoteExtensionNames = []
+    this.exchangeExt = this.registerExtension(EXCHANGE, _exchange)
+    debugger
     this._rextlut = {}
     // namespaced arrays
     this.offeredKeys = {}
@@ -71,6 +79,8 @@ class PeerConnection extends EventEmitter {
       emit.apply(this.stream, args)
     }
     */
+
+    // Clean up theese two as well
     let resolveRemoteVersion = null
     const remoteVersionPromise = defer(d => { resolveRemoteVersion = d })
 
@@ -237,7 +247,8 @@ class PeerConnection extends EventEmitter {
       delete this.extensions[name]
     }
 
-    this.extensions[name] = impl
+    this.extensions.push(impl)
+    debugger
     this._sendOptions()
     return impl
   }

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -1,14 +1,12 @@
-const { EventEmitter } = require('events')
 const assert = require('assert')
 const Protocol = require('hypercore-protocol')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const debugFactory = require('debug')
 const { defer } = require('deferinfer')
-const { assertCore } = require('./util')
+const { assertCore, fastHash } = require('./util')
 const substream = require('hypercore-protocol-substream')
 const ph = require('pretty-hash')
-const { h32 } = require('xxhashjs')
 const codecs = require('codecs')
 const CoreExchangeExtension = require('./exchange')
 
@@ -37,7 +35,10 @@ class PeerConnection {
       onmanifest: opts.onmanifest,
       onrequest: opts.onrequest,
       onstatechange: opts.onstatechange,
-      onreplicating: opts.onreplicating
+      onreplicating: opts.onreplicating,
+      onopen: opts.onopen,
+      onerror: opts.onclose,
+      onextension: opts.onextension
     }
     delete opts.onmanifest
     delete opts.onrequest
@@ -310,7 +311,7 @@ class PeerConnection {
 
     // bubble the message if it's not registered on this peer connection.
     if (typeof ext === 'undefined') {
-      if (this.handlers && typeof this.handlers.onextension === 'function') {
+      if (typeof this.handlers.onextension === 'function') {
         this.handlers.onextension(id, message, this)
       }
       return // Do not process further
@@ -400,8 +401,3 @@ class PeerConnection {
 }
 
 module.exports = PeerConnection
-
-function fastHash (name) {
-  return h32(name, 0xfeed).toNumber()
-}
-

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -248,7 +248,7 @@ class PeerConnection {
 
     impl.destroy = () => {
       this.debug('Unregister extension', name, impl._id.toString(16))
-      this._extentions[impl._id] = null
+      delete this._extensions[impl._id]
     }
 
     this._extensions[impl._id] = impl

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -235,9 +235,11 @@ class PeerConnection {
     if (!impl && typeof name.name === 'string') return this.registerExtension(name.name, name)
     Object.assign(impl, {
       _id: fastHash(name),
-      _codec: codecs(impl.encoding),
-      get name () { return name }
+      _codec: codecs(impl.encoding)
     })
+    if (impl.name !== name) {
+      impl.name = name
+    }
 
     impl.send = message => {
       const buff = impl.encoding ? impl._codec.encode(message) : message

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -21,7 +21,7 @@ const {
 } = require('./constants')
 
 const _exchange = {
-  coding: Exchange,
+  encoding: Exchange,
   onmessage (decodedMessage, peer) {
     debugger
   }
@@ -41,9 +41,7 @@ class PeerConnection extends EventEmitter {
     this.activeVirtual = []
     this.extensions = []
     this.remoteExtensionNames = []
-    this.exchangeExt = this.registerExtension(EXCHANGE, _exchange)
-    debugger
-    this._rextlut = {}
+
     // namespaced arrays
     this.offeredKeys = {}
     this.requestedKeys = {}
@@ -64,6 +62,7 @@ class PeerConnection extends EventEmitter {
     this.exchangeKey = exchangeKey
     this.debug = debugFactory(`decentstack/repl/${this.shortid}`)
 
+
     // Pre-bind our listeners before registering them, to be able to safely remove them
     this.kill = this.kill.bind(this)
 
@@ -79,6 +78,9 @@ class PeerConnection extends EventEmitter {
       emit.apply(this.stream, args)
     }
     */
+
+    // Register the core-exchange protocol
+    this.exchangeExt = this.registerExtension(EXCHANGE, _exchange)
 
     // Clean up theese two as well
     let resolveRemoteVersion = null
@@ -231,30 +233,34 @@ class PeerConnection extends EventEmitter {
   }
 
   registerExtension (name, impl) {
-    impl._codec = impl.coding === 'json' ? codecs('jsonp') : codecs(impl.coding)
+    impl = { ...impl } // Make a copy
+    impl._codec = codecs(impl.encoding)
 
     Object.defineProperty(impl, 'name', {
       get () { return name }
     })
 
     impl.send = message => {
-      debugger
-      // TODO: use this.encoder if encoder
-      this.exchangeChannel.extension(name, message)
+      const buff = impl.encoding ? impl._codec.encode(message) : message
+      this.exchangeChannel.extension(name, buff)
     }
+
+    impl.broadcast = impl.send
 
     impl.destroy = () => {
-      delete this.extensions[name]
+      this.debug('Unregister extension', name, impl._id)
+      this.extensions[impl._id] = null
+      this._sendOptions()
     }
 
-    this.extensions.push(impl)
-    debugger
+    impl._id = this.extensions.push(impl)
+    this.debug('Register extension', name, impl._id)
     this._sendOptions()
     return impl
   }
 
   _sendOptions () {
-    debugger
+    if (!this.exchangeChannel) return
     this.exchangeChannel.options({
       extensions: [PROTOCOL_VERSION, ...this.extensions.map(i => i.name)]
     })
@@ -392,7 +398,10 @@ class PeerConnection extends EventEmitter {
   }
 
   _onExtension (id, message) {
-    const type = this._rextlut[id]
+    const ext = this.extensions[id]
+    debugger
+    if (ext._codec) message = ext._codec.decode(message)
+
     if (typeof type === 'undefined') return console.warn('Unrecognized extension', id)
 
     // Ignore message if not meant for us.

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -37,7 +37,7 @@ class PeerConnection {
       onstatechange: opts.onstatechange,
       onreplicating: opts.onreplicating,
       onopen: opts.onopen,
-      onerror: opts.onclose,
+      onclose: opts.onclose,
       onextension: opts.onextension
     }
     delete opts.onmanifest
@@ -182,7 +182,7 @@ class PeerConnection {
         // if (this.opts.live) this.stream.prefinalize.wait()
         // if (this.opts.live) this.stream.prefinalize.continue() // this dosen't make sense. stream is already marked for death.
         if (typeof this.handlers.onopen === 'function') {
-          this.handlers.onopen(null, this)
+          this.handlers.onopen(this)
         }
         break
     }

--- a/lib/peer-connection.js
+++ b/lib/peer-connection.js
@@ -8,8 +8,8 @@ const { defer } = require('deferinfer')
 const { assertCore } = require('./util')
 const { Exchange } = require('./messages')
 const substream = require('hypercore-protocol-substream')
-const { h32 } = require('xxhashjs')
 const ph = require('pretty-hash')
+const codecs = require('codecs')
 
 const {
   STATE_INIT,
@@ -32,7 +32,9 @@ class PeerConnection extends EventEmitter {
     this.opts = opts || {}
     this.useVirtual = !!opts.useVirtual && false // Disabled for now.
     this.activeVirtual = []
+    this.extensions = new Map()
     this.remoteExtensions = []
+
     this._rextlut = {}
     // namespaced arrays
     this.offeredKeys = {}
@@ -82,9 +84,9 @@ class PeerConnection extends EventEmitter {
       onopen: async () => {
         this.debug('Exchange Channel opened', ph(this.exchangeKey))
         if (!this.stream.remoteVerified(this.exchangeKey)) throw new Error('open and unverified')
-        this.exchangeChannel.options({
-          extensions: [PROTOCOL_VERSION]
-        })
+        this._sendOptions()
+
+        // TODO: clean up, it's not pretty.
         const [lNameVer] = PROTOCOL_VERSION.split('.')
         const remoteVersion = await remoteVersionPromise
         const [rNameVer] = remoteVersion.split('.')
@@ -97,13 +99,6 @@ class PeerConnection extends EventEmitter {
       }
     })
 
-    // Register pre-announced extensions in the
-    // reverse extension lookup table.
-    this.opts.extensions.forEach(e => {
-      this._rextlut[fastHash(e)] = e
-    })
-
-    delete this.opts.extensions
     this.debug(`Initializing new PeerConnection(${this.initiator}) extensions:`, this._rextlut)
 
     eos(this.stream, err => {
@@ -223,6 +218,35 @@ class PeerConnection extends EventEmitter {
     for (const chan of this.activeChannels) {
       chan.close()
     }
+  }
+
+  registerExtension (name, impl) {
+    impl._codec = impl.coding === 'json' ? codecs('jsonp') : codecs(impl.coding)
+
+    Object.defineProperty(impl, 'name', {
+      get () { return name }
+    })
+
+    impl.send = message => {
+      debugger
+      // TODO: use this.encoder if encoder
+      this.exchangeChannel.extension(name, message)
+    }
+
+    impl.destroy = () => {
+      delete this.extensions[name]
+    }
+
+    this.extensions[name] = impl
+    this._sendOptions()
+    return impl
+  }
+
+  _sendOptions () {
+    debugger
+    this.exchangeChannel.options({
+      extensions: [PROTOCOL_VERSION, ...this.extensions.map(i => i.name)]
+    })
   }
 
   _onChannelOpened (discoveryKey) {
@@ -503,6 +527,3 @@ class ManifestResponseTimedOutError extends Error {
   }
 }
 
-function fastHash (name) {
-  return h32(name, 0xfeed).toNumber()
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { h32 } = require('xxhashjs')
 
 const util = {
   // Since this entire project relies on ducktyping,
@@ -51,6 +52,10 @@ const util = {
   readyAll (s, cb) {
     const p = n => !s[n] ? cb(null, s) : s[n].ready(() => p(++n))
     p(0)
+  },
+
+  fastHash (str) {
+    return h32(str, 0xfeed).toNumber()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "git+https://github.com/telamon/replic8.git"
   },
   "dependencies": {
+    "codecs": "^2.0.0",
     "deferinfer": "^1.0.1",
     "end-of-stream": "^1.4.3",
     "hypercore-protocol": "^7.3.0",

--- a/test/index.js
+++ b/test/index.js
@@ -187,7 +187,7 @@ test.skip('Composite-core replication', t => {
 })
 
 test('Hypercore extensions support (local|global)', async t => {
-  t.plan(9)
+  t.plan(10)
   const encryptionKey = Buffer.alloc(32)
   encryptionKey.write('foo bars')
 
@@ -196,7 +196,7 @@ test('Hypercore extensions support (local|global)', async t => {
 
   const conn = new PeerConnection(true, encryptionKey, {
     live: true,
-    onclose: t.error
+    onclose: err => t.error(err, 'Close Handler invoked w/o error')
   })
 
   const peerExt = conn.registerExtension('hello', {

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ test.skip('Composite-core replication', t => {
   })
 })
 
-test('Hypercore extensions', async t => {
+test.only('Hypercore extensions', async t => {
   const encryptionKey = Buffer.alloc(32)
   encryptionKey.write('foo bars')
 
@@ -206,15 +206,18 @@ test('Hypercore extensions', async t => {
   })
 
   const ext1 = conn.registerExtension('hello', {
+    encoding: 'json',
+    onmessage (decodedMessage, peer) {
+      debugger
+      ext1.destroy() // unregisters the extension
+      t.notOk(stack._extensions.hello)
+      t.equal(stack._extNames.indexOf('hello'), -1)
+    }
   })
 
   t.equal(ext1.name, 'hello')
   ext1.broadcast({ world: 'greetings!' })
-  ext1.send({ greetins: true }, conn)
-  ext1.destroy() // unregisters the extension
-  t.notOk(stack._extensions.hello)
-  t.equal(stack._extNames.indexOf('hello'), -1)
-
-  stack.handleConnection(conn.stream, { live: true })
+  stack.handleConnection(false, conn.stream, { live: true })
   conn.stream.once('end', t.end)
+  ext1.send({ greetins: true }, conn)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ test.skip('Composite-core replication', t => {
   })
 })
 
-test.only('Hypercore extensions', async t => {
+test.skip('Hypercore extensions', async t => {
   const encryptionKey = Buffer.alloc(32)
   encryptionKey.write('foo bars')
 
@@ -201,23 +201,24 @@ test.only('Hypercore extensions', async t => {
   const ext2 = conn.registerExtension('hello', {
     encoding: 'json',
     onmessage (decodedMessage, peer) {
+      t.equal(peer, conn, 'PeerConnection should be presented')
       ext2.send({ dead: 'feed' }, peer)
     }
   })
 
-  const ext1 = conn.registerExtension('hello', {
+  const ext1 = stack.registerExtension('hello', {
     encoding: 'json',
     onmessage (decodedMessage, peer) {
-      debugger
-      ext1.destroy() // unregisters the extension
+      t.equal(peer, conn, 'PeerConnection should be presented')
       t.notOk(stack._extensions.hello)
       t.equal(stack._extNames.indexOf('hello'), -1)
+      ext1.destroy() // unregisters the extension
     }
   })
 
   t.equal(ext1.name, 'hello')
-  ext1.broadcast({ world: 'greetings!' })
   stack.handleConnection(false, conn.stream, { live: true })
   conn.stream.once('end', t.end)
-  ext1.send({ greetins: true }, conn)
+
+  ext1.broadcast({ world: 'greetings!' })
 })


### PR DESCRIPTION
Implementing hypercore:v8 extension API as discussed in:
https://github.com/mafintosh/hypercore-protocol/issues/46

API will be exposed on two levels:
```
// Manager wide extensions that might hold a single state across entire application.
const ext = stack.registerExtension('hello', {...})

// Peer specific extensions
const peerConn = stack.replicate(true)
const peerSpecificExt = peerConn.registerExtension('hello', new HelloExtension())
```
The peer specific `ext.send(message, peer)` callback ignores the `peer` argument but accepts it for comaptiblility.